### PR TITLE
Update adoption state for clipboard extension

### DIFF
--- a/clipboard-extension.md
+++ b/clipboard-extension.md
@@ -19,12 +19,13 @@ Conforming terminals MUST support a Pd value that is a base64 encoded representa
 
 If a terminal has an option to disable clipboard access, it MUST only indicate support for this extension when writing to the clipboard is actually allowed.
 
-### Adoption State
+### Terminal Adoption State
 
-| Support | Terminal/Tookit/App                                        | Notes |
+| Support | Terminal                                                   | Notes |
 |---------|------------------------------------------------------------|-------|
 | not yet | [Alacritty](https://github.com/alacritty/alacritty)        | |
-| not yet | [Contour](https://github.com/contour-terminal/contour/)    | [contour#1765](https://github.com/contour-terminal/contour/issues/1765) |
+| ✅      | [Bobcat](https://github.com/ismail-yilmaz/Bobcat)          | [commit](https://github.com/ismail-yilmaz/Terminal/commit/4f62f0fd688d91e802779c30342bc5faceda50ef)|
+| ✅      | [Contour](https://github.com/contour-terminal/contour/)    | [contour#1769](https://github.com/contour-terminal/contour/pull/1769) |
 | not yet | [DomTerm](https://github.com/PerBothner/DomTerm)           | [domterm#124](https://github.com/PerBothner/DomTerm/issues/124) |
 | ✅      | [foot](https://codeberg.org/dnkl/foot)                     | [foot#2130](https://codeberg.org/dnkl/foot/pulls/2130) |
 | not yet | [ghostty](https://github.com/ghostty-org/ghostty)          | [ghostty#7590](https://github.com/ghostty-org/ghostty/discussions/7590) |
@@ -33,12 +34,19 @@ If a terminal has an option to disable clipboard access, it MUST only indicate s
 | not yet | [Konsole](https://konsole.kde.org/)                        | |
 | not yet | [mintty](https://github.com/mintty/mintty)                 | |
 | not yet | [mlterm](https://github.com/arakiken/mlterm)               | [mlterm#144](https://github.com/arakiken/mlterm/issues/144) |
-| not yet | [notcurses](https://github.com/dankamongmen/notcurses)     | |
 | not yet | [st](https://st.suckless.org/)                             | |
-| ✅      | [Bobcat](https://github.com/ismail-yilmaz/Bobcat)          | [commit](https://github.com/ismail-yilmaz/Terminal/commit/4f62f0fd688d91e802779c30342bc5faceda50ef)|
 | not yet | [VTE](https://gitlab.gnome.org/GNOME/vte) / gnome-terminal | |
-| not yet | [Wezterm](https://github.com/wez/wezterm)                  | |
-| not yet  | [Windows Terminal](https://github.com/microsoft/terminal/)| Indicate support for OSC 52 in the DA1 report  by @j4james : [wt#19034](https://github.com/microsoft/terminal/pull/19034) |
-| not yet  | [xterm.js](https://github.com/xtermjs/xterm.js/)          | [xterm#5351](https://github.com/xtermjs/xterm.js/issues/5351) |
+| ✅      | [Wezterm](https://github.com/wez/wezterm)                  | [wezterm#7046](https://github.com/wezterm/wezterm/pull/7046) |
+| ✅      | [Windows Terminal](https://github.com/microsoft/terminal/) | [wt#19034](https://github.com/microsoft/terminal/pull/19034) |
+| not yet | [xterm.js](https://github.com/xtermjs/xterm.js/)           | [xterm#5351](https://github.com/xtermjs/xterm.js/issues/5351) |
+
+### Toolkit/App Adoption State
+
+| Support | Tookit/App                                                 | Notes |
+|---------|------------------------------------------------------------|-------|
+| ✅      | [dte](https://github.com/craigbarnes/dte)                  | [commit](https://github.com/craigbarnes/dte/commit/bed8412692d2363e1198e838393b0f0cb1c197d8) |
+| not yet | [neovim](https://github.com/neovim/neovim)                 | [neovim#34472](https://github.com/neovim/neovim/issues/34472) |
+| not yet | [notcurses](https://github.com/dankamongmen/notcurses)     | |
+| ✅      | [tmux](https://github.com/tmux/tmux)                       | [commit](https://github.com/tmux/tmux/commit/d858ad1179d98fb5ab31a4e077e789200ef7e411) |
 
 In case some project is adding support for this feature, please leave a comment or contact me, so we can keep the spec and implementation state table up to date.


### PR DESCRIPTION
Support for the clipboard extension has now been committed in Contour, WezTerm, and Windows Terminal, as well tmux and the dte editor.

And since we're starting to get more app support, I thought might be best to split the Toolkit/Apps off into separate table.

I also repositioned the entry for Bobcat in the Terminal table so it's in alphabetical order.