### PR TITLE
Update adoption state for synchronized output and clipboard extensions

### DIFF
--- a/clipboard-extension.md
+++ b/clipboard-extension.md
@@ -1,10 +1,10 @@
 # Clipboard Extension
 
-The Clipboard Extension supports copying to the clipboard using a subset of the XTerm OSC 52 escape sequence. 
+The Clipboard Extension supports copying to the clipboard using a subset of the XTerm `OSC 52` escape sequence.
 
 ## Feature detection
 
-Support for this functionality in a terminal is indicated by the extension parameter 52 in the Device Attributes (DA) report.
+Support for this functionality in a terminal is indicated by the extension parameter `52` in the Device Attributes (`DA`) report.
 
 ## Syntax
 The escape sequence has the following syntax:
@@ -13,9 +13,9 @@ The escape sequence has the following syntax:
 OSC 52 ; Pc ; Pd ST
 ```
 
-Conforming terminals MUST at least support an empty Pc value, and a Pc value of c. Other values are optional.
+Conforming terminals MUST at least support an empty _Pc_ value, and a _Pc_ value of `c`. Other values are optional.
 
-Conforming terminals MUST support a Pd value that is a base64 encoded representation of the content that will be copied to the clipboard. They SHOULD also support an empty Pd value to clear the clipboard. They MAY support a Pd value of ? to query the clipboard content (as specified in the XTerm documentation).
+Conforming terminals MUST support a _Pd_ value that is a base64 encoded representation of the content that will be copied to the clipboard. They SHOULD also support an empty _Pd_ value to clear the clipboard. They MAY support a _Pd_ value of `?` to query the clipboard content (as specified in the XTerm documentation).
 
 If a terminal has an option to disable clipboard access, it MUST only indicate support for this extension when writing to the clipboard is actually allowed.
 
@@ -28,9 +28,9 @@ If a terminal has an option to disable clipboard access, it MUST only indicate s
 | ✅      | [Contour](https://github.com/contour-terminal/contour/)    | [contour#1769](https://github.com/contour-terminal/contour/pull/1769) |
 | not yet | [DomTerm](https://github.com/PerBothner/DomTerm)           | [domterm#124](https://github.com/PerBothner/DomTerm/issues/124) |
 | ✅      | [foot](https://codeberg.org/dnkl/foot)                     | [foot#2130](https://codeberg.org/dnkl/foot/pulls/2130) |
-| not yet | [ghostty](https://github.com/ghostty-org/ghostty)          | [ghostty#7590](https://github.com/ghostty-org/ghostty/discussions/7590) |
+| ✅      | [ghostty](https://github.com/ghostty-org/ghostty)          | [commit](https://github.com/ghostty-org/ghostty/commit/259228698873c0c934741445ec6790cfafb64502) |
 | not yet | [iTerm2](https://github.com/gnachman/iTerm2)               | |
-| not yet | [Kitty](https://github.com/kovidgoyal/kitty)               | |
+| ✅      | [Kitty](https://github.com/kovidgoyal/kitty)               | [commit](https://github.com/kovidgoyal/kitty/commit/eabddc287043083e25f57b236df7f0c9883760a5) |
 | not yet | [Konsole](https://konsole.kde.org/)                        | |
 | not yet | [mintty](https://github.com/mintty/mintty)                 | |
 | not yet | [mlterm](https://github.com/arakiken/mlterm)               | [mlterm#144](https://github.com/arakiken/mlterm/issues/144) |

--- a/synchronized-output.md
+++ b/synchronized-output.md
@@ -63,24 +63,25 @@ than having no synchronized output at all.
 
 ### Adoption State
 
-| Support | Terminal/Tookit/App   | Notes  |
-|---------|------------|--------|
-| n/a     | xterm.js   | see tracker [xterm.js#3375](https://github.com/xtermjs/xterm.js/issues/3375) |
-| not yet | Windows Terminal | Proof-of-concept implementation by @j4james exists; tracker: [wt#8331](https://github.com/microsoft/terminal/issues/8331)  |
-| ✅      | Contour    | |
-| ✅      | mintty     | |
-| ✅      | Jexer      | |
-| ✅      | notcurses  | see tracker: [notcurses#1582](https://github.com/dankamongmen/notcurses/issues/1582) |
-| ✅      | foot       | terminal emulator https://codeberg.org/dnkl/foot
-| ✅    | Wezterm    | see tracker: [wezterm#882](https://github.com/wez/wezterm/issues/882) |
-| not yet | VTE / gnome-terminal | see tracker: [gitlab/vte#15](https://gitlab.gnome.org/GNOME/vte/-/issues/15) |
-| ✅      | iTerm2     | |
-| ✅      | Kitty      | since [5768c54c5b5763e4bbb300726b8ff71b40c128f8](https://github.com/kovidgoyal/kitty/commit/5768c54c5b5763e4bbb300726b8ff71b40c128f8) |
-| planned | Warp       | see tracker: https://github.com/warpdotdev/Warp/issues/2185 |
-| unknown | Alacritty  | |
-| unknown | [Konsole](https://konsole.kde.org/)    | |
-| unknown | urxvt      | |
-| unknown | [st](https://st.suckless.org/) | |
+| Support | Terminal/Tookit/App                                        | Notes |
+|---------|------------------------------------------------------------|-------|
+| ✅      | [Alacritty](https://github.com/alacritty/alacritty)        | [alacritty#96](https://github.com/alacritty/vte/pull/96) |
+| ✅      | [Contour](https://github.com/contour-terminal/contour/)    | |
+| ✅      | [foot](https://codeberg.org/dnkl/foot)                     | |
+| ✅      | [ghostty](https://github.com/ghostty-org/ghostty)          | [commit](https://github.com/ghostty-org/ghostty/commit/2cc1e4371651ccd692f3e8e8ba5a5cf731b2e21f) |
+| ✅      | [iTerm2](https://github.com/gnachman/iTerm2)               | |
+| ✅      | [Jexer](https://gitlab.com/AutumnMeowMeow/jexer)           | |
+| ✅      | [Kitty](https://github.com/kovidgoyal/kitty)               | [commit](https://github.com/kovidgoyal/kitty/commit/5768c54c5b5763e4bbb300726b8ff71b40c128f8) |
+| unknown | [Konsole](https://konsole.kde.org/)                        | |
+| ✅      | [mintty](https://github.com/mintty/mintty)                 | |
+| ✅      | [notcurses](https://github.com/dankamongmen/notcurses)     | [notcurses#1582](https://github.com/dankamongmen/notcurses/issues/1582) |
+| unknown | [st](https://st.suckless.org/)                             | |
+| unknown | [urxvt](https://software.schmorp.de/pkg/rxvt-unicode.html) | |
+| not yet | [VTE](https://gitlab.gnome.org/GNOME/vte) / gnome-terminal | [gitlab/vte#15](https://gitlab.gnome.org/GNOME/vte/-/issues/15) |
+| ✅      | [Warp](https://github.com/warpdotdev/Warp)                 | [warp#2185](https://github.com/warpdotdev/Warp/issues/2185) |
+| ✅      | [Wezterm](https://github.com/wez/wezterm)                  | [wezterm#882](https://github.com/wez/wezterm/issues/882) |
+| ✅      | [Windows Terminal](https://github.com/microsoft/terminal/) | [wt#18826](https://github.com/microsoft/terminal/pull/18826) |
+| not yet | [xterm.js](https://github.com/xtermjs/xterm.js/)           | [xterm.js#3375](https://github.com/xtermjs/xterm.js/issues/3375) |
 
 
 In case some project is adding support for this feature, please leave a comment or contact me, so we can keep the spec and implementation state table up to date.


### PR DESCRIPTION
Ghostty and Kitty now support the clipboard extension, and Alacritty, Ghostty, Warp and Windows Terminal have added support for the synchronized output extension.

I've also added a bit of markup to the clipboard spec text to make it a little more readable, and added links to the terminals names in the synchronized output extension, and sorted the terminal list.
