### PR TITLE
Add Bobcat support to sync output doc

### DIFF
--- a/synchronized-output.md
+++ b/synchronized-output.md
@@ -66,6 +66,7 @@ than having no synchronized output at all.
 | Support | Terminal/Tookit/App                                        | Notes |
 |---------|------------------------------------------------------------|-------|
 | ✅      | [Alacritty](https://github.com/alacritty/alacritty)        | [alacritty#96](https://github.com/alacritty/vte/pull/96) |
+| ✅      | [Bobcat](https://github.com/ismail-yilmaz/Bobcat)          | [v.0.9.9 (r401 and on)](https://github.com/ismail-yilmaz/Terminal/commit/010ef40218a58fb5ce70132a773c806bc67c480c) |
 | ✅      | [BossTerm](https://github.com/kshivang/BossTerm)           | [v1.0.54](https://github.com/kshivang/BossTerm/releases/tag/v1.0.54) |
 | ✅      | [Contour](https://github.com/contour-terminal/contour/)    | |
 | ✅      | bubbletea | https://github.com/charmbracelet/bubbletea/discussions/1320 |


### PR DESCRIPTION
This PR adds Bobcat to the list of TEs that support synchronized output mode.
This mode is available on Bobcat v0.9.9, r401 and on.